### PR TITLE
Add OopsSec Store to Other Useful Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Repository | Description
 [Linux Kernel Exploitation](https://github.com/xairy/linux-kernel-exploitation) | A bunch of links related to Linux kernel fuzzing and exploitation
 [Lockpicking](https://github.com/meitar/awesome-lockpicking) | Resources relating to the security and compromise of locks, safes, and keys.
 [Machine Learning for Cyber Security](https://github.com/jivoi/awesome-ml-for-cybersecurity)   | Curated list of tools and resources related to the use of machine learning for cyber security
+[OSS – OopsSec Store](https://github.com/kOaDT/oss-oopssec-store) | Intentionally vulnerable e-commerce application for web security training with CTF challenges
 [Payloads](https://github.com/foospidy/payloads)  | Collection of web attack payloads
 [PayloadsAllTheThings](https://github.com/swisskyrepo/PayloadsAllTheThings)   | List of useful payloads and bypass for Web Application Security and Pentest/CTF
 [Pentest Cheatsheets](https://github.com/coreb1t/awesome-pentest-cheat-sheets)		| Collection of the cheat sheets useful for pentesting


### PR DESCRIPTION
This PR adds OopsSec Store to the Other Useful Repositories section.

I am the owner and maintainer of this project. I believe it can be a valuable resource for the security community and would like to share it with others who might find it useful for penetration testing practice, security training, and CTF challenges.

The project can be quickly set up using `npx create-oss-store` and provides a production-like environment with REST APIs.

**Repository:** https://github.com/kOaDT/oss-oopssec-store
