### PR TITLE
Add NullSec Linux to Other Useful Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Repository | Description
 [IOC](https://github.com/sroberts/awesome-iocs) 									| Collection of sources of indicators of compromise
 [Linux Kernel Exploitation](https://github.com/xairy/linux-kernel-exploitation) | A bunch of links related to Linux kernel fuzzing and exploitation
 [Lockpicking](https://github.com/meitar/awesome-lockpicking) | Resources relating to the security and compromise of locks, safes, and keys.
+[NullSec Linux](https://github.com/bad-antics/nullsec-linux) | Security-focused Linux distribution with 115+ pre-installed penetration testing and security tools
 [Machine Learning for Cyber Security](https://github.com/jivoi/awesome-ml-for-cybersecurity)   | Curated list of tools and resources related to the use of machine learning for cyber security
 [Payloads](https://github.com/foospidy/payloads)  | Collection of web attack payloads
 [PayloadsAllTheThings](https://github.com/swisskyrepo/PayloadsAllTheThings)   | List of useful payloads and bypass for Web Application Security and Pentest/CTF


### PR DESCRIPTION
## Description
Adding NullSec Linux - a security-focused Linux distribution with 115+ pre-installed penetration testing and security tools.

## Entry Added
- **Repository**: [NullSec Linux](https://github.com/bad-antics/nullsec-linux)
- **Section**: Other Useful Repositories
- **Alphabetical Order**: Yes (between Lockpicking and Machine Learning)

## About NullSec Linux
A comprehensive security distribution designed for penetration testing, red team operations, and security research. Includes tools for:
- Network reconnaissance and scanning
- Web application testing
- Wireless security
- Password cracking
- Forensics and reverse engineering
- Exploitation frameworks

Thank you for maintaining this excellent resource!