### PR TITLE
Add dna-claude-analysis to Other Useful Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Repository | Description
 [CVE PoC updated daily](https://github.com/trickest/cve) | List of CVE Proof of Concepts (PoCs) updated daily by Trickest
 [CyberChef](https://gchq.github.io/CyberChef/) | A simple, intuitive web app for analysing and decoding data without having to deal with complex tools or programming languages.
 [Detection Lab](https://github.com/clong/DetectionLab)                              |  Vagrant & Packer scripts to build a lab environment complete with security tooling and logging best practices
+[DNA Claude Analysis](https://github.com/shmlkv/dna-claude-analysis) | Personal genome analysis toolkit with terminal/hacker aesthetic — Matrix-style green-on-black single-page HTML dashboard, Python scripts for DNA data analysis
 [Forensics](https://github.com/Cugu/awesome-forensics) 								| List of awesome forensic analysis tools and resources
 [Free Programming Books](https://github.com/EbookFoundation/free-programming-books) 			| Free programming books for developers
 [Gray Hacker Resources](https://github.com/bt3gl/Gray-Hacker-Resources) 			| Useful for CTFs, wargames, pentesting


### PR DESCRIPTION
## What

Adds [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) to the **Other Useful Repositories** section, placed alphabetically between *Detection Lab* and *Forensics*.

## Why

The project is a personal genome analysis toolkit with a terminal/hacker aesthetic. It produces a Matrix-style green-on-black single-page HTML dashboard from raw DNA data, using Python scripts for analysis. It fits the spirit of the list as a niche, technically-focused hacking/OSINT-adjacent tool for researchers interested in bioinformatics and personal data analysis.

## Checklist

- [x] Entry is placed in alphabetical order within its section
- [x] Description matches the format of surrounding entries (no trailing period, concise)
- [x] Link points to the correct public GitHub repository