### PR TITLE
Add operant-mcp to Other Useful Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Repository | Description
 [Linux Kernel Exploitation](https://github.com/xairy/linux-kernel-exploitation) | A bunch of links related to Linux kernel fuzzing and exploitation
 [Lockpicking](https://github.com/meitar/awesome-lockpicking) | Resources relating to the security and compromise of locks, safes, and keys.
 [Machine Learning for Cyber Security](https://github.com/jivoi/awesome-ml-for-cybersecurity)   | Curated list of tools and resources related to the use of machine learning for cyber security
+[operant-mcp](https://github.com/operantlabs/operant-mcp) | Open-source MCP server with 51 security testing tools across 19 modules (SQLi, XSS, CMDi, SSRF, PCAP forensics, recon, memory forensics, malware analysis, and more)
 [Payloads](https://github.com/foospidy/payloads)  | Collection of web attack payloads
 [PayloadsAllTheThings](https://github.com/swisskyrepo/PayloadsAllTheThings)   | List of useful payloads and bypass for Web Application Security and Pentest/CTF
 [Pentest Cheatsheets](https://github.com/coreb1t/awesome-pentest-cheat-sheets)		| Collection of the cheat sheets useful for pentesting


### PR DESCRIPTION
## Summary
- Adds [operant-mcp](https://github.com/operantlabs/operant-mcp) to the **Other Useful Repositories** section
- Open-source MCP server providing 51 security testing tools across 19 modules:
  - SQL injection (6 tools), XSS, command injection, SSRF, path traversal
  - PCAP/network forensics (8 tools), reconnaissance (7 tools)
  - Memory forensics (Volatility), malware document analysis, CloudTrail analysis
  - Authentication testing, CORS, clickjacking, NoSQL injection, deserialization, GraphQL introspection
- Enables AI-driven security testing via the Model Context Protocol
- Install via `npx operant-mcp`
- MIT licensed, written in TypeScript