### PR TITLE
Add keyFinder - Chrome extension for detecting leaked API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Repository | Description
 [Infosec Getting Started](https://github.com/gradiuscypher/infosec_getting_started)					| A collection of resources, documentation, links, etc to help people learn about Infosec
 [Infosec Reference](https://github.com/rmusser01/Infosec_Reference) 				| Information Security Reference That Doesn't Suck
 [IOC](https://github.com/sroberts/awesome-iocs) 									| Collection of sources of indicators of compromise
+[keyFinder](https://github.com/momenbasel/keyFinder) | Chrome extension that passively scans web pages for exposed API keys, tokens, and secrets using 80+ regex patterns and Shannon entropy
 [Linux Kernel Exploitation](https://github.com/xairy/linux-kernel-exploitation) | A bunch of links related to Linux kernel fuzzing and exploitation
 [Lockpicking](https://github.com/meitar/awesome-lockpicking) | Resources relating to the security and compromise of locks, safes, and keys.
 [Machine Learning for Cyber Security](https://github.com/jivoi/awesome-ml-for-cybersecurity)   | Curated list of tools and resources related to the use of machine learning for cyber security

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Repository | Description
 [Infosec Getting Started](https://github.com/gradiuscypher/infosec_getting_started) | A collection of resources, documentation, links, etc to help people learn about Infosec
 [Infosec Reference](https://github.com/rmusser01/Infosec_Reference) | Information Security Reference That Doesn't Suck
 [IOC](https://github.com/sroberts/awesome-iocs) | Collection of sources of indicators of compromise
+[keyFinder](https://github.com/momenbasel/keyFinder) | Chrome extension that passively scans web pages for exposed API keys, tokens, and secrets using 80+ regex patterns and Shannon entropy
 [Linux Kernel Exploitation](https://github.com/xairy/linux-kernel-exploitation) | A bunch of links related to Linux kernel fuzzing and exploitation
 [Machine Learning for Cyber Security](https://github.com/jivoi/awesome-ml-for-cybersecurity) | Curated list of tools and resources related to the use of machine learning for cyber security
 [Payloads](https://github.com/foospidy/payloads) | Collection of web attack payloads


### PR DESCRIPTION
## Summary

- Adds [keyFinder](https://github.com/momenbasel/keyFinder) to the **Other Useful Repositories** section
- Alphabetical order maintained (between IOC and Linux Kernel Exploitation)
- Follows existing table format

## About keyFinder

- Chrome extension (556+ stars, MIT license, Manifest V3)
- Passively scans every web page for exposed API keys, tokens, and secrets
- Uses 80+ regex patterns and Shannon entropy analysis across 10 attack surfaces
- Zero dependencies, lightweight
- Useful for security researchers, bug bounty hunters, and penetration testers