### PR TITLE
Add HTB Writeups to Awesome Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Repository | Description
 [Fuzzing](https://github.com/secfigo/Awesome-Fuzzing) 								| List of fuzzing resources for learning Fuzzing and initial phases of Exploit Development like root cause analysis
 [Hacking](https://github.com/carpedm20/awesome-hacking) 						| List of awesome Hacking tutorials, tools and resources
 [Hacking Resources](https://github.com/vitalysim/Awesome-Hacking-Resources)          | Collection of hacking / penetration testing resources to make you better!
+[HTB Writeups](https://github.com/momenbasel/htb-writeups) | Comprehensive Hack The Box writeup collection covering machines, challenges, ProLabs, Sherlocks, CTF events, and certification prep guides
 [Honeypots](https://github.com/paralax/awesome-honeypots) 							| List of honeypot resources
 [Incident Response](https://github.com/meirwah/awesome-incident-response) 			| List of tools for incident response
 [Industrial Control System Security](https://github.com/hslatman/awesome-industrial-control-system-security)      | List of resources related to Industrial Control System (ICS) security

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Repository | Description
 [Fuzzing](https://github.com/secfigo/Awesome-Fuzzing) | List of fuzzing resources for learning Fuzzing and initial phases of Exploit Development like root cause analysis
 [Hacking](https://github.com/carpedm20/awesome-hacking) | List of awesome Hacking tutorials, tools and resources
 [Honeypots](https://github.com/paralax/awesome-honeypots) | List of honeypot resources
+[HTB Writeups](https://github.com/momenbasel/htb-writeups) | Comprehensive Hack The Box writeup collection covering machines, challenges, ProLabs, Sherlocks, CTF events, and certification prep guides
 [Incident Response](https://github.com/meirwah/awesome-incident-response) | List of tools for incident response
 [Industrial Control System Security](https://github.com/hslatman/awesome-industrial-control-system-security) | List of resources related to Industrial Control System (ICS) security
 [InfoSec](https://github.com/onlurking/awesome-infosec) | List of awesome infosec courses and training resources


### PR DESCRIPTION
## Summary

- Adds [HTB Writeups](https://github.com/momenbasel/htb-writeups) to the **Awesome Repositories** table in alphabetical order
- The repository is a comprehensive Hack The Box writeup collection covering 500+ machines, 400+ challenges, ProLabs, Sherlocks (DFIR), CTF events, cheatsheets, and certification prep guides (OSCP/CPTS/CRTO)
- Entry placed between "Hacking Resources" and "Honeypots" to maintain alphabetical order

## Checklist

- [x] Entry added to `README.md`
- [x] Alphabetical order maintained
- [x] Format matches existing entries (Repository | Description table)
- [x] Link is valid and repository is public