### PR TITLE
Add basic CI workflow with build job

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,0 +1,36 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "master" branch
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -17,8 +17,10 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
+      # Prefer a dedicated repository secret LOCK_THREADS_TOKEN (set to a PAT ≤ 100 chars).
+      # Fallback to the built-in token if LOCK_THREADS_TOKEN is not set.
       - uses: dessant/lock-threads@v5
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.LOCK_THREADS_TOKEN || secrets.GITHUB_TOKEN }}
           issue-inactive-days: '7'
           pr-inactive-days: '7'

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -19,5 +19,6 @@ jobs:
     steps:
       - uses: dessant/lock-threads@v5
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-inactive-days: '7'
           pr-inactive-days: '7'


### PR DESCRIPTION
This workflow is set up to run on push or pull request events for the master branch, and can also be triggered manually.