### PR TITLE
Add Z-Jail – Linux sandbox with seccomp-BPF and zero dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Repository | Description
 [Tor](https://github.com/polycarbohydrate/awesome-tor) | Resources about the Tor network and anonymous communication
 [Vulhub](https://github.com/vulhub/vulhub) | Pre-Built Vulnerable Environments Based on Docker-Compose
 [Web Security](https://github.com/qazbnm456/awesome-web-security) | Curated list of Web Security materials and resources
+[Z-Jail](https://github.com/Division-36/Z-Jail) | Lightweight multi-layer Linux sandbox (namespaces, pivot_root, seccomp-BPF) for secure execution of untrusted code
+
 
 ## Need More ?
 


### PR DESCRIPTION
## What I'm adding

Z-Jail is a lightweight Linux sandbox written in C99.

- 7 independent defense layers: setrlimit, fd scrub, pivot_root, 
  PR_SET_NO_NEW_PRIVS, capability drop, seccomp-BPF whitelist (15 syscalls)
- ~130 KiB binary, zero external dependencies
- Built-in audit log with BLAKE2b-256 content hashing
- Single `make` build

Fits under the existing pattern for sandboxing/isolation tools 
relevant to CTF and CI/CD security.

Repo: https://github.com/Division-36/Z-Jail