### PR TITLE
Add Bug Bounty Roadmap to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Repository | Description
 [AppSec](https://github.com/paragonie/awesome-appsec) | Resources for learning about application security
 [Asset Discovery](https://github.com/redhuntlabs/Awesome-Asset-Discovery) | List of resources which help during asset discovery phase of a security assessment engagement
 [Bug Bounty](https://github.com/djadmin/awesome-bug-bounty) | List of Bug Bounty Programs and write-ups from the Bug Bounty hunters
+[Bug Bounty Roadmap](https://bugbountyroadmap.netlify.app/) | Interactive roadmap to learn bug bounty from zero, mapping every topic, book, tool and platform in one visual graph
 [Cellular Hacking](https://github.com/W00t3k/Awesome-Cellular-Hacking) | This is a list of hacking research in the 3G/4G/5G cellular security space. 
 [CI/CD Attacks](https://github.com/TupleType/awesome-cicd-attacks) | Offensive research of CI/CD systems and deployment processes
 [CTF](https://github.com/apsdehal/awesome-ctf) | List of CTF frameworks, libraries, resources and softwares


### PR DESCRIPTION
Adds Bug Bounty Roadmap to the Awesome Repositories table, alphabetically
between Bug Bounty and Cellular Hacking.

Live: https://bugbountyroadmap.netlify.app/

It's a study path for bug bounty laid out as a clickable force-directed
graph instead of a flat markdown list. You pick a node, read why it
matters, and follow the connections to what comes next.

- 9 stages ordered fundamentals to advanced: networking & Linux, web,
  cloud, vuln classes & tooling, platforms, recon & scripting, active
  hunting, and optional branches for exploit dev and vulnerability research.
- 78 topics and ~145 curated links behind them: 33 books, 30 practice
  platforms, 41 tools, 41 write-ups/research blogs. Each one has a short
  note on where it fits and why it's worth your time, not just a bare link.
- Nodes are wired to related nodes, so the order to learn things is shown
  rather than left for a beginner to guess.
- Progress is saved locally so you can track what's left.

The existing Bug Bounty entry links programs and write-ups. This is the
part before that: what to actually learn, and in what order, before you
start hunting. Thanks for maintaining the list.