### PR TITLE
chore: update lock-threads from v5 to v6.0.2

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -17,7 +17,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v5
+      - uses: dessant/lock-threads@v6.0.2
         with:
           issue-inactive-days: '7'
           pr-inactive-days: '7'


### PR DESCRIPTION
## Summary

- Update `dessant/lock-threads` from v5 to v6.0.2
- v5 targets Node 20 which GitHub has deprecated; the runner forces it to Node 24 where it fails with `"github-token" length must be less than or equal to 100 characters long`
- v6.0.2 natively targets Node 24, fixing the failure

This workflow runs hourly and has been failing on every run, generating CI failure notifications.

## Test plan

- [ ] Verify the workflow passes on the next scheduled run (top of the hour)
- [ ] Or trigger manually via workflow_dispatch